### PR TITLE
build: fix duplicated symbol when linking

### DIFF
--- a/src/libespeak-ng/mbrowrap.c
+++ b/src/libespeak-ng/mbrowrap.c
@@ -18,12 +18,23 @@
  */
 
 #include "config.h"
+#include "mbrowrap.h"
+
+int (WINAPI *init_MBR)(char *voice_path);
+void (WINAPI *close_MBR)(void);
+void (WINAPI *reset_MBR)(void);
+int (WINAPI *read_MBR)(short *buffer, int nb_samples);
+int (WINAPI *write_MBR)(char *data);
+int (WINAPI *flush_MBR)(void);
+int (WINAPI *getFreq_MBR)(void);
+void (WINAPI *setVolumeRatio_MBR)(float value);
+char * (WINAPI *lastErrorStr_MBR)(char *buffer, int bufsize);
+void (WINAPI *setNoError_MBR)(int no_error);
 
 #if defined(_WIN32) || defined(_WIN64)
 
 #include <windows.h>
 
-#include "mbrowrap.h"
 
 HINSTANCE hinstDllMBR = NULL;
 
@@ -69,8 +80,6 @@ void unload_MBR()
 #include <unistd.h>
 
 #include <espeak-ng/espeak_ng.h>
-
-#include "mbrowrap.h"
 #include "speech.h"
 
 /*

--- a/src/libespeak-ng/mbrowrap.h
+++ b/src/libespeak-ng/mbrowrap.h
@@ -37,20 +37,20 @@ typedef int BOOL;
  * error reason.  If this is successful, then close_MBR() must be called
  * before init_MBR() can be called again.
  */
-int (WINAPI *init_MBR)(char *voice_path);
+extern int (WINAPI *init_MBR)(char *voice_path);
 
 /*
  * Stop mbrola and release any resources.  It is necessary to call
  * this after a successful call to init_MBR() before init_MBR() can be
  * called again.
  */
-void (WINAPI *close_MBR)(void);
+extern void (WINAPI *close_MBR)(void);
 
 /*
  * Stop any ongoing processing and flush all buffers.  After this call
  * any synthesis request will start afresh.
  */
-void (WINAPI *reset_MBR)(void);
+extern void (WINAPI *reset_MBR)(void);
 
 /*
  * Return at most 'nb_samples' audio samples into 'buffer'. The returned
@@ -58,14 +58,14 @@ void (WINAPI *reset_MBR)(void);
  * If not successful, lastErrorStr_MBR() will provide the error reason.
  * Samples are always 16-bit little endian.
  */
-int (WINAPI *read_MBR)(short *buffer, int nb_samples);
+extern int (WINAPI *read_MBR)(short *buffer, int nb_samples);
 
 /*
  * Write a NULL terminated string of phoneme in the input buffer.
  * Return the number of chars actually written, or -1 on error.
  * If not successful, lastErrorStr_MBR() will provide the error reason.
  */
-int (WINAPI *write_MBR)(char *data);
+extern int (WINAPI *write_MBR)(char *data);
 
 /*
  * Send a flush command to the mbrola input stream.
@@ -73,17 +73,17 @@ int (WINAPI *write_MBR)(char *data);
  * or 0 on failure. If not successful, lastErrorStr_MBR() will provide
  * the error reason.
  */
-int (WINAPI *flush_MBR)(void);
+extern int (WINAPI *flush_MBR)(void);
 
 /*
  * Return the audio sample frequency of the used voice database.
  */
-int (WINAPI *getFreq_MBR)(void);
+extern int (WINAPI *getFreq_MBR)(void);
 
 /*
  * Overall volume.
  */
-void (WINAPI *setVolumeRatio_MBR)(float value);
+extern void (WINAPI *setVolumeRatio_MBR)(float value);
 
 /*
  * Copy into 'buffer' at most 'bufsize' bytes from the latest error
@@ -91,12 +91,12 @@ void (WINAPI *setVolumeRatio_MBR)(float value);
  * no error message is pending then an empty string is returned.
  * Consecutive calls to lastErrorStr_MBR() will return the same message.
  */
-char * (WINAPI *lastErrorStr_MBR)(char *buffer, int bufsize);
+extern char * (WINAPI *lastErrorStr_MBR)(char *buffer, int bufsize);
 
 /*
  * Tolerance to missing diphones.
  */
-void (WINAPI *setNoError_MBR)(int no_error);
+extern void (WINAPI *setNoError_MBR)(int no_error);
 
 BOOL load_MBR(void);
 void unload_MBR(void);


### PR DESCRIPTION
Hey @rhdunn, I'm starting to build this awesome project on my OSX, but meet the following error when linking:

```
duplicate symbol _init_MBR in:
    src/libespeak-ng/.libs/src_libespeak_ng_la-synth_mbrola.o
    src/libespeak-ng/.libs/src_libespeak_ng_la-mbrowrap.o
duplicate symbol _reset_MBR in:
    src/libespeak-ng/.libs/src_libespeak_ng_la-synth_mbrola.o
    src/libespeak-ng/.libs/src_libespeak_ng_la-mbrowrap.o
...
```

This error is caused by here we occurs the same issue as [stackoverflow#c-duplicate-symbol-from-function-pointer](https://stackoverflow.com/questions/19127981/c-duplicate-symbol-from-function-pointer). This patch'd fix this problem :)