### PR TITLE
build, encoding: include stdint

### DIFF
--- a/src/include/espeak-ng/encoding.h
+++ b/src/include/espeak-ng/encoding.h
@@ -17,6 +17,8 @@
 #ifndef ESPEAK_NG_ENCODING_H
 #define ESPEAK_NG_ENCODING_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C"
 {


### PR DESCRIPTION
The `stdint.h` is not included when building test, then including this module inside `encoding.h`, the error is the following:

```sh
1 warning generated.
  CCLD     tests/tokenizer.test
  CC       tests/tests_readclause_test-readclause.o
  CCLD     tests/readclause.test
  CC       tests/tests_api_test-api.o
In file included from tests/api.c:27:
src/include/espeak-ng/encoding.h:88:15: error: unknown type name 'uint32_t'
ESPEAK_NG_API uint32_t
              ^
src/include/espeak-ng/encoding.h:91:15: error: unknown type name 'uint32_t'
ESPEAK_NG_API uint32_t
              ^
In file included from tests/api.c:31:
src/libespeak-ng/synthesize.h:451:8: error: unknown type name 'intptr_t'
extern intptr_t wcmdq[N_WCMDQ][4];
       ^
In file included from tests/api.c:32:
src/libespeak-ng/translate.h:238:32: error: unknown type name 'uint32_t'
int clause_type_from_codepoint(uint32_t c);
```

/cc @rhdunn 