### PR TITLE
tests/language.test: Use different hashing commands when needed

### DIFF
--- a/tests/languages.test
+++ b/tests/languages.test
@@ -1,5 +1,24 @@
 #!/bin/sh
 
+# Test a command for presence and ability to output the sha1 hash of a file.
+check_hashcmd() {
+	which $1 >&/dev/null &&
+	$1 </dev/null 2>/dev/null |
+	awk '{if ($1 != "da39a3ee5e6b4b0d3255bfef95601890afd80709") { exit 1; }}'
+}
+
+# Test some common commands to find the correct one for the system being tested on.
+if check_hashcmd sha1sum; then
+	sha1sum=sha1sum
+elif check_hashcmd sha1; then
+	sha1sum=sha1
+elif check_hashcmd shasum; then
+	sha1sum=shasum
+else
+	echo "No hashing commands found."
+	false
+fi
+
 test_lang() {
 	if test "$#" -eq 3; then
 		TEST_LANG=$1
@@ -16,7 +35,7 @@ test_lang() {
 	echo "testing ${TEST_NAME}"
 	ESPEAK_DATA_PATH=`pwd` LD_LIBRARY_PATH=src:${LD_LIBRARY_PATH} \
 		src/espeak-ng --stdout -v ${TEST_LANG} "${TEST_TEXT}" | \
-		sha1sum | awk '{ print $1 }' > actual.txt
+		$sha1sum | awk '{ print $1 }' > actual.txt
 	echo "${EXPECTED}" > expected.txt
 	diff expected.txt actual.txt || exit 1
 }


### PR DESCRIPTION
Testing fix for #107

Outside of Linux platforms, sha1 hashing from the command-line is accomplished by commands other than sha1sum. OSX uses shasum (from Perl) and FreeBSD uses sha1, so I've added in detection for the appropriate command before falling back and failing the test.

This could be further enhanced by adding an OpenSSL sha1sum command as well.