### PR TITLE
Freebsd build fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,23 @@ else
 fi
 
 dnl ================================================================
+dnl FreeBSD check.
+dnl ================================================================
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+		   #if ! defined(__FreeBSD__)
+		   #error macro not defined
+		   #endif
+		   ]])], [FREEBSD_FOUND="yes"], [FREEBSD_FOUND="no"])
+
+AC_MSG_CHECKING([if targeting FreeBSD])
+if test "$FREEBSD_FOUND" = "yes" ; then
+	AC_MSG_RESULT([-D__BSD_VISIBLE])
+	CFLAGS="$CFLAGS -D__BSD_VISIBLE"
+else
+	AC_MSG_RESULT([no])
+fi
+
+dnl ================================================================
 dnl library checks.
 dnl ================================================================
 

--- a/src/include/compat/wchar.h
+++ b/src/include/compat/wchar.h
@@ -32,7 +32,4 @@
 
 #include <ucd/ucd.h>
 
-#define towlower ucd_tolower
-#define towupper ucd_toupper
-
 #endif

--- a/src/libespeak-ng/readclause.c
+++ b/src/libespeak-ng/readclause.c
@@ -163,7 +163,7 @@ int towlower2(unsigned int c)
 	if (c == 'I' && translator->langopts.dotless_i)
 		return 0x131; // I -> ı
 
-	return towlower(c);
+	return ucd_tolower(c);
 }
 
 static int IsRomanU(unsigned int c)
@@ -842,7 +842,7 @@ static int attrnumber(const wchar_t *pw, int default_value, int type)
 
 	while (IsDigit09(*pw))
 		value = value*10 + *pw++ - '0';
-	if ((type == 1) && (towlower(*pw) == 's')) {
+	if ((type == 1) && (ucd_tolower(*pw) == 's')) {
 		// time: seconds rather than ms
 		value *= 1000;
 	}

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -1791,13 +1791,13 @@ static int SubstituteChar(Translator *tr, unsigned int c, unsigned int next_in, 
 		// don't convert the case of the second character unless the next letter is also upper case
 		c2 = new_c >> 16;
 		if (upper_case && iswupper(next_in))
-			c2 = towupper(c2);
+			c2 = ucd_toupper(c2);
 		*insert = c2;
 		new_c &= 0xffff;
 	}
 
 	if (upper_case)
-		new_c = towupper(new_c);
+		new_c = ucd_toupper(new_c);
 
 	*wordflags |= FLAG_CHAR_REPLACED;
 	return new_c;

--- a/src/ucd-tools/tests/printcdata.c
+++ b/src/ucd-tools/tests/printcdata.c
@@ -178,7 +178,7 @@ void uprintf(FILE *out, codepoint_t c, const char *format)
 			uprintf_is(out, c, *++format);
 			break;
 		case 'L': /* lowercase */
-			uprintf_codepoint(out, towlower(c), *++format);
+			uprintf_codepoint(out, ucd_tolower(c), *++format);
 			break;
 		case 's': /* script */
 			fputs(ucd_get_script_string(ucd_lookup_script(c)), out);
@@ -187,7 +187,7 @@ void uprintf(FILE *out, codepoint_t c, const char *format)
 			uprintf_codepoint(out, ucd_totitle(c), *++format);
 			break;
 		case 'U': /* uppercase */
-			uprintf_codepoint(out, towupper(c), *++format);
+			uprintf_codepoint(out, ucd_toupper(c), *++format);
 			break;
 		}
 		++format;


### PR DESCRIPTION
Build fixes for #107 

Two different issues fixed in this PR. The first deals with visibility of `mkstemp()` and `M_PI` in the system libraries by setting `-D__BSD_VISIBLE` in the CFLAGS using the configure script, the second deals with the name-collision of `towlower()` and `towupper()` also in the system libraries by removing the `#define` statements in `src/include/compat/wchar.h` and replacing the cases where the define is used with the `ucd_` equivalent.
