### PR TITLE
David Weenink

### DIFF
--- a/src/espeak-ng.c
+++ b/src/espeak-ng.c
@@ -126,7 +126,7 @@ FILE *f_wavfile = NULL;
 char filetype[5];
 char wavefile[200];
 
-void DisplayVoices(FILE *f_out, char *language)
+static void DisplayVoices(FILE *f_out, char *language)
 {
 	int ix;
 	const char *p;
@@ -197,7 +197,7 @@ static void Write4Bytes(FILE *f, int value)
 	}
 }
 
-int OpenWavFile(char *path, int rate)
+static int OpenWavFile(char *path, int rate)
 {
 	static unsigned char wave_hdr[44] = {
 		'R', 'I', 'F', 'F', 0x24, 0xf0, 0xff, 0x7f, 'W', 'A', 'V', 'E', 'f', 'm', 't', ' ',

--- a/src/include/espeak-ng/speak_lib.h
+++ b/src/include/espeak-ng/speak_lib.h
@@ -211,7 +211,7 @@ typedef int (t_espeak_callback)(short*, int, espeak_EVENT*);
 #ifdef __cplusplus
 extern "C"
 #endif
-ESPEAK_API void grep (t_espeak_callback* SynthCallback);
+ESPEAK_API void espeak_SetSynthCallback(t_espeak_callback* SynthCallback);
 /* Must be called before any synthesis functions are called.
    This specifies a function in the calling program which is called when a buffer of
    speech sound data has been produced.
@@ -288,8 +288,6 @@ ESPEAK_API espeak_ERROR espeak_Synth(const void *text,
 	unsigned int flags,
 	unsigned int* unique_identifier,
 	void* user_data);
-
-ESPEAK_API void espeak_SetSynthCallback(t_espeak_callback *SynthCallback);
 /* Synthesize speech for the specified text.  The speech sound data is passed to the calling
    program in buffers by means of the callback function specified by espeak_SetSynthCallback(). The command is asynchronous: it is internally buffered and returns as soon as possible. If espeak_Initialize was previously called with AUDIO_OUTPUT_PLAYBACK as argument, the sound data are played by eSpeak.
 

--- a/src/include/espeak-ng/speak_lib.h
+++ b/src/include/espeak-ng/speak_lib.h
@@ -211,7 +211,7 @@ typedef int (t_espeak_callback)(short*, int, espeak_EVENT*);
 #ifdef __cplusplus
 extern "C"
 #endif
-ESPEAK_API void espeak_SetSynthCallback(t_espeak_callback* SynthCallback);
+ESPEAK_API void grep (t_espeak_callback* SynthCallback);
 /* Must be called before any synthesis functions are called.
    This specifies a function in the calling program which is called when a buffer of
    speech sound data has been produced.
@@ -288,6 +288,8 @@ ESPEAK_API espeak_ERROR espeak_Synth(const void *text,
 	unsigned int flags,
 	unsigned int* unique_identifier,
 	void* user_data);
+
+ESPEAK_API void espeak_SetSynthCallback(t_espeak_callback *SynthCallback);
 /* Synthesize speech for the specified text.  The speech sound data is passed to the calling
    program in buffers by means of the callback function specified by espeak_SetSynthCallback(). The command is asynchronous: it is internally buffered and returns as soon as possible. If espeak_Initialize was previously called with AUDIO_OUTPUT_PLAYBACK as argument, the sound data are played by eSpeak.
 

--- a/src/libespeak-ng/compiledata.c
+++ b/src/libespeak-ng/compiledata.c
@@ -33,13 +33,13 @@
 
 #include <espeak-ng/espeak_ng.h>
 #include <espeak-ng/speak_lib.h>
+#include <espeak-ng/encoding.h>
 
 #include "error.h"
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
-#include "voice.h"
 #include "spect.h"
+#include "translate.h"
 
 typedef struct {
 	unsigned int value;
@@ -51,7 +51,7 @@ int n_manifest;
 char phsrc[sizeof(path_home)+40]; // Source: path to the 'phonemes' source file.
 
 extern ESPEAK_NG_API int utf8_in(int *c, const char *buf);
-extern int utf8_out(unsigned int c, char *buf);
+//extern int utf8_out(unsigned int c, char *buf);
 
 typedef struct {
 	const char *mnem;
@@ -722,7 +722,7 @@ static void unget_char(unsigned int c)
 		linenum--;
 }
 
-int CheckNextChar()
+static int CheckNextChar()
 {
 	int c;
 	while (((c = get_char()) == ' ') || (c == '\t'))
@@ -893,7 +893,7 @@ static int Range(int value, int divide, int min, int max)
 	return value - min;
 }
 
-int CompileVowelTransition(int which)
+static int CompileVowelTransition(int which)
 {
 	// Compile a vowel transition
 	int key;
@@ -999,7 +999,7 @@ int CompileVowelTransition(int which)
 	return 0;
 }
 
-espeak_ng_STATUS LoadSpect(const char *path, int control, int *addr)
+static espeak_ng_STATUS LoadSpect(const char *path, int control, int *addr)
 {
 	SpectSeq *spectseq;
 	int peak;
@@ -1614,7 +1614,7 @@ static void CompileSound(int keyword, int isvowel)
    =8         data = stress bitmap
    =9         special tests
  */
-int CompileIf(int elif)
+static int CompileIf(int elif)
 {
 	int key;
 	int finish = 0;
@@ -1723,7 +1723,7 @@ int CompileIf(int elif)
 	return 0;
 }
 
-void FillThen(int add)
+static void FillThen(int add)
 {
 	USHORT *p;
 	int offset;
@@ -1751,7 +1751,7 @@ void FillThen(int add)
 	then_count = 0;
 }
 
-int CompileElse(void)
+static int CompileElse(void)
 {
 	USHORT *ref;
 	USHORT *p;
@@ -1778,7 +1778,7 @@ int CompileElse(void)
 	return 0;
 }
 
-int CompileElif(void)
+static int CompileElif(void)
 {
 	if (if_level < 1) {
 		error("ELIF not expected");
@@ -1790,7 +1790,7 @@ int CompileElif(void)
 	return 0;
 }
 
-int CompileEndif(void)
+static int CompileEndif(void)
 {
 	USHORT *p;
 	int chain;
@@ -1953,7 +1953,7 @@ static void DecThenCount()
 		then_count--;
 }
 
-int CompilePhoneme(int compile_phoneme)
+static int CompilePhoneme(int compile_phoneme)
 {
 	int endphoneme = 0;
 	int keyword;
@@ -2699,7 +2699,7 @@ MNEM_TAB envelope_names[] = {
 	{ NULL, -1 }
 };
 
-int LookupEnvelopeName(const char *name)
+static int LookupEnvelopeName(const char *name)
 {
 	return LookupMnem(envelope_names, name);
 }

--- a/src/libespeak-ng/compiledict.c
+++ b/src/libespeak-ng/compiledict.c
@@ -34,12 +34,13 @@
 
 #include "error.h"
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
 #include "translate.h"
 
 extern void Write4Bytes(FILE *f, int value);
 int HashDictionary(const char *string);
+void print_dictionary_flags(unsigned int *flags, char *buf, int buf_len);
+char *DecodeRule(const char *group_chars, int group_length, char *rule, int control);
 
 static FILE *f_log = NULL;
 extern char *dir_dictionary;
@@ -762,7 +763,7 @@ static int group3_ix;
 
 #define N_RULES 3000 // max rules for each group
 
-int isHexDigit(int c)
+static int isHexDigit(int c)
 {
 	if ((c >= '0') && (c <= '9'))
 		return c - '0';
@@ -1169,7 +1170,7 @@ static char *compile_rule(char *input)
 	return prule;
 }
 
-int __cdecl string_sorter(char **a, char **b)
+static int __cdecl string_sorter(char **a, char **b)
 {
 	char *pa, *pb;
 	int ix;

--- a/src/libespeak-ng/compilembrola.c
+++ b/src/libespeak-ng/compilembrola.c
@@ -29,7 +29,6 @@
 #include <espeak-ng/speak_lib.h>
 
 #include "error.h"
-#include "phoneme.h"
 #include "speech.h"
 #include "synthesize.h"
 

--- a/src/libespeak-ng/dictionary.c
+++ b/src/libespeak-ng/dictionary.c
@@ -32,7 +32,6 @@
 #include <espeak-ng/encoding.h>
 
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
 #include "translate.h"
 

--- a/src/libespeak-ng/encoding.c
+++ b/src/libespeak-ng/encoding.c
@@ -26,6 +26,8 @@
 #include <espeak-ng/encoding.h>
 
 #include "speech.h"
+#include "synthesize.h"
+#include "translate.h"
 
 #define LEADING_2_BITS 0xC0 // 0b11000000
 #define UTF8_TAIL_BITS 0x80 // 0b10000000

--- a/src/libespeak-ng/error.c
+++ b/src/libespeak-ng/error.c
@@ -28,7 +28,6 @@
 
 #include "error.h"
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
 
 espeak_ng_STATUS

--- a/src/libespeak-ng/espeak_api.c
+++ b/src/libespeak-ng/espeak_api.c
@@ -28,7 +28,6 @@
 #include <espeak-ng/encoding.h>
 
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
 #include "translate.h"
 #include "event.h"

--- a/src/libespeak-ng/event.c
+++ b/src/libespeak-ng/event.c
@@ -66,8 +66,8 @@ static node *head = NULL;
 static node *tail = NULL;
 static int node_counter = 0;
 static espeak_ng_STATUS push(void *data);
-static void *pop();
-static void init();
+static void *pop(void);
+static void init(void);
 static void *polling_thread(void *);
 
 void event_set_callback(t_espeak_callback *SynthCallback)

--- a/src/libespeak-ng/event.h
+++ b/src/libespeak-ng/event.h
@@ -52,14 +52,14 @@ void event_init(void);
 void event_set_callback(t_espeak_callback *cb);
 
 // Clear any pending event.
-espeak_ng_STATUS event_clear_all();
+espeak_ng_STATUS event_clear_all(void);
 
 // Declare a future event
 espeak_ng_STATUS event_declare(espeak_EVENT *event);
 
 // Terminate the event component.
 // Last function to be called.
-void event_terminate();
+void event_terminate(void);
 
 // general functions
 void clock_gettime2(struct timespec *ts);

--- a/src/libespeak-ng/fifo.c
+++ b/src/libespeak-ng/fifo.c
@@ -58,7 +58,7 @@ static int my_stop_is_acknowledged = 0;
 static void *say_thread(void *);
 
 static espeak_ng_STATUS push(t_espeak_command *the_command);
-static t_espeak_command *pop();
+static t_espeak_command *pop(void);
 static void init(int process_parameters);
 static int node_counter = 0;
 

--- a/src/libespeak-ng/fifo.h
+++ b/src/libespeak-ng/fifo.h
@@ -29,7 +29,7 @@ extern "C"
 
 // Initialize the fifo component.
 // First function to be called.
-void fifo_init();
+void fifo_init(void);
 
 // Add an espeak command.
 //
@@ -44,15 +44,15 @@ espeak_ng_STATUS fifo_add_command(t_espeak_command *c);
 espeak_ng_STATUS fifo_add_commands(t_espeak_command *c1, t_espeak_command *c2);
 
 // The current running command must be stopped and the awaiting commands are cleared.
-espeak_ng_STATUS fifo_stop();
+espeak_ng_STATUS fifo_stop(void);
 
 // Is there a running command?
 // Returns 1 if yes; 0 otherwise.
-int fifo_is_busy();
+int fifo_is_busy(void);
 
 // Terminate the fifo component.
 // Last function to be called.
-void fifo_terminate();
+void fifo_terminate(void);
 
 // Indicates if the running command is still enabled.
 //
@@ -61,7 +61,7 @@ void fifo_terminate();
 // stopping speech as soon as a cancel command is applied.
 //
 // Returns 1 if yes, or 0 otherwise.
-int fifo_is_command_enabled();
+int fifo_is_command_enabled(void);
 
 #ifdef __cplusplus
 }

--- a/src/libespeak-ng/ieee80.c
+++ b/src/libespeak-ng/ieee80.c
@@ -95,10 +95,17 @@ typedef float Single;
 #define SEXP_SIZE		8
 #define SEXP_POSITION	(32-SEXP_SIZE-1)
 
+// prototypes:
 
-defdouble
-ConvertFromIeeeSingle(bytes)
-char* bytes;
+defdouble ConvertFromIeeeSingle (char *bytes);
+void ConvertToIeeeSingle(defdouble num, char *bytes);
+defdouble ConvertFromIeeeDouble(char * bytes);
+defdouble ConvertFromIeeeExtended(char * bytes);
+void ConvertToIeeeDouble (defdouble num, char * bytes);
+defdouble ConvertFromIeeeDouble(char * bytes);
+void ConvertToIeeeExtended(defdouble num, char * bytes);
+
+defdouble ConvertFromIeeeSingle(char * bytes)
 {
 	defdouble	f;
 	long	mantissa, expon;
@@ -140,10 +147,7 @@ char* bytes;
 /****************************************************************/
 
 
-void
-ConvertToIeeeSingle(num, bytes)
-defdouble num;
-char* bytes;
+void ConvertToIeeeSingle(defdouble num, char* bytes)
 {
 	long	sign;
 	register long bits;
@@ -209,9 +213,7 @@ char* bytes;
 #define DEXP_POSITION	(32-DEXP_SIZE-1)
 
 
-defdouble
-ConvertFromIeeeDouble(bytes)
-char* bytes;
+defdouble ConvertFromIeeeDouble(char* bytes)
 {
 	defdouble	f;
 	long	mantissa, expon;
@@ -259,10 +261,7 @@ char* bytes;
 /****************************************************************/
 
 
-void
-ConvertToIeeeDouble(num, bytes)
-defdouble num;
-char *bytes;
+void ConvertToIeeeDouble(defdouble num, char *bytes)
 {
 	long	sign;
 	long	first, second;
@@ -343,9 +342,7 @@ char *bytes;
  * and a 64-bit mantissa, with no hidden bit.
  ****************************************************************/
 
-defdouble
-ConvertFromIeeeExtended(bytes)
-char* bytes;
+defdouble ConvertFromIeeeExtended(char* bytes)
 {
 	defdouble	f;
 	long	expon;
@@ -385,10 +382,7 @@ char* bytes;
 /****************************************************************/
 
 
-void
-ConvertToIeeeExtended(num, bytes)
-defdouble num;
-char *bytes;
+void ConvertToIeeeExtended(defdouble num, char * bytes)
 {
 	int	sign;
 	int expon;

--- a/src/libespeak-ng/intonation.c
+++ b/src/libespeak-ng/intonation.c
@@ -29,9 +29,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
-#include "voice.h"
 #include "translate.h"
 
 /* Note this module is mostly old code that needs to be rewritten to

--- a/src/libespeak-ng/klatt.c
+++ b/src/libespeak-ng/klatt.c
@@ -36,9 +36,6 @@
 
 #include "speech.h"
 #include "klatt.h"
-#include "phoneme.h"
-#include "synthesize.h"
-#include "voice.h"
 
 extern unsigned char *out_ptr;
 extern unsigned char *out_start;
@@ -846,7 +843,7 @@ static int klattp[N_KLATTP];
 static double klattp1[N_KLATTP];
 static double klattp_inc[N_KLATTP];
 
-int Wavegen_Klatt(int resume)
+static int Wavegen_Klatt(int resume)
 {
 	int pk;
 	int x;
@@ -935,7 +932,7 @@ int Wavegen_Klatt(int resume)
 	return 0;
 }
 
-void SetSynth_Klatt(int length, frame_t *fr1, frame_t *fr2, voice_t *v, int control)
+static void SetSynth_Klatt(int length, frame_t *fr1, frame_t *fr2, voice_t *v, int control)
 {
 	int ix;
 	DOUBLEX next;

--- a/src/libespeak-ng/klatt.h
+++ b/src/libespeak-ng/klatt.h
@@ -21,6 +21,8 @@
  * along with this program; if not, see: <http://www.gnu.org/licenses/>.
  */
 
+#include "synthesize.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -171,6 +173,9 @@ typedef struct {
 	DOUBLEX bp_inc;
 }  klatt_peaks_t;
 
+void KlattInit(void);
+void KlattReset(int control);
+int Wavegen_Klatt2(int length, int resume, frame_t *fr1, frame_t *fr2);
 
 #ifdef __cplusplus
 }

--- a/src/libespeak-ng/mbrowrap.c
+++ b/src/libespeak-ng/mbrowrap.c
@@ -519,7 +519,7 @@ static ssize_t receive_from_mbrola(void *buffer, size_t bufsize)
  * API functions.
  */
 
-int init_mbrola(char *voice_path)
+static int init_mbrola(char *voice_path)
 {
 	int error, result;
 	unsigned char wavhdr[45];
@@ -562,7 +562,7 @@ int init_mbrola(char *voice_path)
 	return 0;
 }
 
-void close_mbrola(void)
+static void close_mbrola(void)
 {
 	stop_mbrola();
 	free_pending_data();
@@ -571,7 +571,7 @@ void close_mbrola(void)
 	mbr_volume = 1.0;
 }
 
-void reset_mbrola(void)
+static void reset_mbrola(void)
 {
 	int result, success = 1;
 	char dummybuf[4096];
@@ -595,7 +595,7 @@ void reset_mbrola(void)
 		mbr_state = MBR_IDLE;
 }
 
-int read_mbrola(short *buffer, int nb_samples)
+static int read_mbrola(short *buffer, int nb_samples)
 {
 	int result = receive_from_mbrola(buffer, nb_samples * 2);
 	if (result > 0)
@@ -603,23 +603,23 @@ int read_mbrola(short *buffer, int nb_samples)
 	return result;
 }
 
-int write_mbrola(char *data)
+static int write_mbrola(char *data)
 {
 	mbr_state = MBR_NEWDATA;
 	return send_to_mbrola(data);
 }
 
-int flush_mbrola(void)
+static int flush_mbrola(void)
 {
 	return send_to_mbrola("\n#\n") == 3;
 }
 
-int getFreq_mbrola(void)
+static int getFreq_mbrola(void)
 {
 	return mbr_samplerate;
 }
 
-void setVolumeRatio_mbrola(float value)
+static void setVolumeRatio_mbrola(float value)
 {
 	if (value == mbr_volume)
 		return;
@@ -634,7 +634,7 @@ void setVolumeRatio_mbrola(float value)
 	init_MBR(mbr_voice_path);
 }
 
-char *lastErrorStr_mbrola(char *buffer, int bufsize)
+static char *lastErrorStr_mbrola(char *buffer, int bufsize)
 {
 	if (mbr_pid)
 		mbrola_has_errors();
@@ -642,7 +642,7 @@ char *lastErrorStr_mbrola(char *buffer, int bufsize)
 	return buffer;
 }
 
-void setNoError_mbrola(int no_error)
+static void setNoError_mbrola(int no_error)
 {
 	(void)no_error; // unused
 }

--- a/src/libespeak-ng/numbers.c
+++ b/src/libespeak-ng/numbers.c
@@ -32,9 +32,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
-#include "voice.h"
 #include "translate.h"
 
 #define M_LIGATURE  0x8000
@@ -548,7 +546,7 @@ static const int number_ranges[] = {
 	0
 };
 
-int NonAsciiNumber(int letter)
+static int NonAsciiNumber(int letter)
 {
 	// Change non-ascii digit into ascii digit '0' to '9', (or -1 if not)
 	const int *p;
@@ -1711,7 +1709,7 @@ static int LookupNum3(Translator *tr, int value, char *ph_out, int suppress_null
 	return 0;
 }
 
-bool CheckThousandsGroup(char *word, int group_len)
+static bool CheckThousandsGroup(char *word, int group_len)
 {
 	// Is this a group of 3 digits which looks like a thousands group?
 	int ix;

--- a/src/libespeak-ng/phonemelist.c
+++ b/src/libespeak-ng/phonemelist.c
@@ -29,7 +29,6 @@
 #include <espeak-ng/encoding.h>
 
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
 #include "translate.h"
 

--- a/src/libespeak-ng/readclause.c
+++ b/src/libespeak-ng/readclause.c
@@ -38,9 +38,7 @@
 
 #include "error.h"
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
-#include "voice.h"
 #include "translate.h"
 
 #define N_XML_BUF   500
@@ -919,7 +917,7 @@ static int attr_prosody_value(int param_type, const wchar_t *pw, int *value_out)
 	return sign;   // -1, 0, or 1
 }
 
-int AddNameData(const char *name, int wide)
+static int AddNameData(const char *name, int wide)
 {
 	// Add the name to the namedata and return its position
 	// (Used by the Windows SAPI wrapper)

--- a/src/libespeak-ng/setlengths.c
+++ b/src/libespeak-ng/setlengths.c
@@ -27,15 +27,11 @@
 #include <espeak-ng/espeak_ng.h>
 #include <espeak-ng/speak_lib.h>
 #include <espeak-ng/encoding.h>
-
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
-#include "voice.h"
 #include "translate.h"
 
 extern int GetAmplitude(void);
-extern void DoSonicSpeed(int value);
 extern int saved_parameters[];
 
 // convert from words-per-minute to internal speed factor

--- a/src/libespeak-ng/spect.c
+++ b/src/libespeak-ng/spect.c
@@ -31,9 +31,7 @@
 #include <espeak-ng/speak_lib.h>
 
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
-#include "voice.h"
 #include "spect.h"
 
 extern double ConvertFromIeeeExtended(unsigned char *bytes);
@@ -237,7 +235,7 @@ double GetFrameRms(SpectFrame *frame, int seq_amplitude)
 	return frame->rms;
 }
 
-SpectSeq *SpectSeqCreate()
+SpectSeq *SpectSeqCreate(void)
 {
 	SpectSeq *spect = malloc(sizeof(SpectSeq));
 	if (!spect)

--- a/src/libespeak-ng/spect.h
+++ b/src/libespeak-ng/spect.h
@@ -124,7 +124,7 @@ typedef struct {
 	int file_format;
 } SpectSeq;
 
-SpectSeq *SpectSeqCreate();
+SpectSeq *SpectSeqCreate(void);
 void SpectSeqDestroy(SpectSeq *spect);
 espeak_ng_STATUS LoadSpectSeq(SpectSeq *spect, const char *filename);
 

--- a/src/libespeak-ng/speech.c
+++ b/src/libespeak-ng/speech.c
@@ -49,9 +49,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
-#include "voice.h"
 #include "translate.h"
 #include "espeak_command.h"
 #include "fifo.h"
@@ -612,6 +610,7 @@ ESPEAK_API void espeak_SetUriCallback(int (*UriCallback)(int, const char *, cons
 	uri_callback = UriCallback;
 }
 
+ESPEAK_API void espeak_SetPhonemeCallback(int (*PhonemeCallback)(const char *));
 ESPEAK_API void espeak_SetPhonemeCallback(int (*PhonemeCallback)(const char *))
 {
 	phoneme_callback = PhonemeCallback;
@@ -875,9 +874,6 @@ ESPEAK_NG_API espeak_ng_STATUS espeak_ng_Synchronize(void)
 	err = ENS_OK;
 	return berr;
 }
-
-extern void FreePhData(void);
-extern void FreeVoiceList(void);
 
 ESPEAK_NG_API espeak_ng_STATUS espeak_ng_Terminate(void)
 {

--- a/src/libespeak-ng/speech.h
+++ b/src/libespeak-ng/speech.h
@@ -49,6 +49,10 @@ extern "C"
 #define __cdecl
 
 #endif
+	
+// used in synthesize.h and voice.h	
+#define N_PEAKS   9
+#define N_PEAKS2  9 // plus Notch and Fill (not yet implemented)
 
 // will look for espeak_data directory here, and also in user's home directory
 #ifndef PATH_ESPEAK_DATA

--- a/src/libespeak-ng/synth_mbrola.c
+++ b/src/libespeak-ng/synth_mbrola.c
@@ -32,10 +32,8 @@
 #include <espeak-ng/encoding.h>
 
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
 #include "translate.h"
-#include "voice.h"
 
 #ifdef INCLUDE_MBROLA
 

--- a/src/libespeak-ng/synthdata.c
+++ b/src/libespeak-ng/synthdata.c
@@ -33,9 +33,7 @@
 
 #include "error.h"
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
-#include "voice.h"
 #include "translate.h"
 
 const char *version_string = PACKAGE_VERSION;

--- a/src/libespeak-ng/synthesize.c
+++ b/src/libespeak-ng/synthesize.c
@@ -32,9 +32,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
-#include "voice.h"
 #include "translate.h"
 
 extern FILE *f_log;

--- a/src/libespeak-ng/synthesize.h
+++ b/src/libespeak-ng/synthesize.h
@@ -17,6 +17,9 @@
  * along with this program; if not, see: <http://www.gnu.org/licenses/>.
  */
 
+#include "phoneme.h"
+#include "voice.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -74,8 +77,6 @@ extern "C"
 extern int embedded_value[N_EMBEDDED_VALUES];
 extern int embedded_default[N_EMBEDDED_VALUES];
 
-#define N_PEAKS   9
-#define N_PEAKS2  9 // plus Notch and Fill (not yet implemented)
 #define N_MARKERS 8
 
 #define N_KLATTP   10 // this affects the phoneme data file format
@@ -453,14 +454,18 @@ extern int wcmdq_head;
 extern int wcmdq_tail;
 
 // from Wavegen file
-int  WcmdqFree();
-void WcmdqStop();
-int  WcmdqUsed();
-void WcmdqInc();
+int  WcmdqFree(void);
+void WcmdqStop(void);
+int  WcmdqUsed(void);
+void WcmdqInc(void);
 void WavegenInit(int rate, int wavemult_fact);
 float polint(float xa[], float ya[], int n, float x);
-int WavegenFill();
+int WavegenFill(void);
 void MarkerEvent(int type, unsigned int char_position, int value, int value2, unsigned char *out_ptr);
+int PeaksToHarmspect(wavegen_peaks_t *peaks, int pitch, int *htab, int control);
+int Wavegen(void);
+void SetPitch2(voice_t *voice, int pitch1, int pitch2, int *pitch_base, int *pitch_range);
+void SetPitch(int length, unsigned char *env, int pitch1, int pitch2); 
 
 extern unsigned char *wavefile_data;
 extern int samplerate;
@@ -488,6 +493,7 @@ frameref_t *LookupSpect(PHONEME_TAB *this_ph, int which, FMT_PARAMS *fmt_params,
 
 unsigned char *LookupEnvelope(int ix);
 espeak_ng_STATUS LoadPhData(int *srate, espeak_ng_ERROR_CONTEXT *context);
+void FreePhData(void);
 
 void SynthesizeInit(void);
 int  Generate(PHONEME_LIST *phoneme_list, int *n_ph, int resume);
@@ -538,16 +544,19 @@ void DoMarker(int type, int char_posn, int length, int value);
 void DoPhonemeMarker(int type, int char_posn, int length, char *name);
 int DoSample3(PHONEME_DATA *phdata, int length_mod, int amp);
 int DoSpect2(PHONEME_TAB *this_ph, int which, FMT_PARAMS *fmt_params,  PHONEME_LIST *plist, int modulation);
+int FormantTransition2(frameref_t *seq, int *n_frames, unsigned int data1, unsigned int data2, PHONEME_TAB *other_ph, int which);
 int PauseLength(int pause, int control);
 int LookupPhonemeTable(const char *name);
 unsigned char *GetEnvelope(int index);
 int NumInstnWords(USHORT *prog);
+int GetAmplitude(void);
 
 void InitBreath(void);
 
-void KlattInit();
-void KlattReset(int control);
-int Wavegen_Klatt2(int length, int resume, frame_t *fr1, frame_t *fr2);
+
+#if HAVE_SONIC_H
+	void DoSonicSpeed(int value);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/libespeak-ng/tr_languages.c
+++ b/src/libespeak-ng/tr_languages.c
@@ -31,7 +31,6 @@
 #include <espeak-ng/encoding.h>
 
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
 #include "translate.h"
 
@@ -412,7 +411,7 @@ static void SetCyrillicLetters(Translator *tr)
 	SetLetterBits(tr, LETTERGP_VOWEL2, (char *)ru_vowels);
 }
 
-void SetIndicLetters(Translator *tr)
+static void SetIndicLetters(Translator *tr)
 {
 	// Set letter types for Indic scripts, Devanagari, Tamill, etc
 	static const char dev_consonants2[] = { 0x02, 0x03, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f, 0x7b, 0x7c, 0x7e, 0x7f, 0 };
@@ -437,7 +436,7 @@ void SetIndicLetters(Translator *tr)
 	tr->langopts.suffix_add_e = tr->letter_bits_offset + 0x4d; // virama
 }
 
-void SetupTranslator(Translator *tr, const short *lengths, const unsigned char *amps)
+static void SetupTranslator(Translator *tr, const short *lengths, const unsigned char *amps)
 {
 	if (lengths != NULL)
 		memcpy(tr->stress_lengths, lengths, sizeof(tr->stress_lengths));

--- a/src/libespeak-ng/translate.c
+++ b/src/libespeak-ng/translate.c
@@ -32,9 +32,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
-#include "voice.h"
 #include "translate.h"
 
 Translator *translator = NULL; // the main translator
@@ -254,7 +252,7 @@ int IsDigit(unsigned int c)
 	return 0;
 }
 
-int IsSpace(unsigned int c)
+static int IsSpace(unsigned int c)
 {
 	if (c == 0)
 		return 0;
@@ -396,7 +394,7 @@ char *strchr_w(const char *s, int c)
 	return strchr((char *)s, c); // (char *) is needed for Borland compiler
 }
 
-int IsAllUpper(const char *word)
+static int IsAllUpper(const char *word)
 {
 	int c;
 	while ((*word != 0) && !isspace2(*word)) {
@@ -1195,7 +1193,7 @@ static int CountSyllables(unsigned char *phonemes)
 	return count;
 }
 
-void Word_EmbeddedCmd()
+static void Word_EmbeddedCmd()
 {
 	// Process embedded commands for emphasis, sayas, and break
 	int embedded_cmd;
@@ -1874,7 +1872,7 @@ static int TranslateChar(Translator *tr, char *ptr, int prev_in, unsigned int c,
 
 static const char *UCase_ga[] = { "bp", "bhf", "dt", "gc", "hA", "mb", "nd", "ng", "ts", "tA", "nA", NULL };
 
-int UpperCaseInWord(Translator *tr, char *word, int c)
+static int UpperCaseInWord(Translator *tr, char *word, int c)
 {
 	int ix;
 	int len;

--- a/src/libespeak-ng/translate.h
+++ b/src/libespeak-ng/translate.h
@@ -746,6 +746,7 @@ void LookupLetter(Translator *tr, unsigned int letter, int next_byte, char *ph_b
 void LookupAccentedLetter(Translator *tr, unsigned int letter, char *ph_buf);
 
 int LoadDictionary(Translator *tr, const char *name, int no_error);
+int HashDictionary(const char *string);
 int LookupDictList(Translator *tr, char **wordptr, char *ph_out, unsigned int *flags, int end_flags, WORD_TAB *wtab);
 
 void MakePhonemeList(Translator *tr, int post_pause, int new_sentence);

--- a/src/libespeak-ng/voice.h
+++ b/src/libespeak-ng/voice.h
@@ -82,6 +82,7 @@ const char *SelectVoice(espeak_VOICE *voice_select, int *found);
 espeak_VOICE *SelectVoiceByName(espeak_VOICE **voices, const char *name);
 voice_t *LoadVoice(const char *voice_name, int control);
 voice_t *LoadVoiceVariant(const char *voice_name, int variant);
+void FreeVoiceList(void);
 espeak_ng_STATUS DoVoiceChange(voice_t *v);
 void WavegenSetVoice(voice_t *v);
 void ReadTonePoints(char *string, int *tone_pts);

--- a/src/libespeak-ng/voices.c
+++ b/src/libespeak-ng/voices.c
@@ -39,9 +39,7 @@
 #include <espeak-ng/encoding.h>
 
 #include "speech.h"
-#include "phoneme.h"
 #include "synthesize.h"
-#include "voice.h"
 #include "translate.h"
 
 MNEM_TAB genders[] = {

--- a/src/libespeak-ng/wavegen.c
+++ b/src/libespeak-ng/wavegen.c
@@ -32,9 +32,7 @@
 #include <espeak-ng/speak_lib.h>
 
 #include "speech.h"
-#include "phoneme.h"
-#include "synthesize.h"
-#include "voice.h"
+#include "klatt.h"
 
 #if HAVE_SONIC_H
 #include "sonic.h"
@@ -1140,7 +1138,7 @@ void SetPitch(int length, unsigned char *env, int pitch1, int pitch2)
 	flutter_amp = wvoice->flutter;
 }
 
-void SetSynth(int length, int modn, frame_t *fr1, frame_t *fr2, voice_t *v)
+static void SetSynth(int length, int modn, frame_t *fr1, frame_t *fr2, voice_t *v)
 {
 	if (wvoice == NULL || v == NULL)
 		return;
@@ -1246,7 +1244,7 @@ void Write4Bytes(FILE *f, int value)
 	}
 }
 
-int WavegenFill2()
+static int WavegenFill2()
 {
 	// Pick up next wavegen commands from the queue
 	// return: 0  output buffer has been filled


### PR DESCRIPTION
I would like to use libespeak-ng in praat (http://www.praat.org). Currently we are still using espeak-1.48. 
Using the compiler options CC=gcc CFLAGS="-Werror=missing-prototypes -Werror=implicit -Wreturn-type -Wunused -Wunused-parameter -Wuninitialized" spawns a lot of errors/warning about missing prototypes and so on.
This patch tries to make the compiler more happy.
If you accept this patch or use it, it makes it more easy for me to keep in sync with your great work.

Thank you in advance

David Weenink